### PR TITLE
Improve test reliability by cleaning state pollution after running test_register_inclusion_renderer

### DIFF
--- a/fanstatic/test_core.py
+++ b/fanstatic/test_core.py
@@ -765,6 +765,7 @@ def test_register_inclusion_renderer():
     needed = NeededResources()
     needed.need(a)
     assert needed.render() == ('<link rel="unknown" href="/fanstatic/foo/nothing.unknown" />')
+    del inclusion_renderers['.unknown']
 
 
 def test_registered_inclusion_renderers_in_order():


### PR DESCRIPTION
This PR aims to improve the reliability of the test `test_register_inclusion_renderer` by cleaning the polluted state after test execution.

The test can fail in the following way if the polluted state is not cleaned:
```
        with pytest.raises(UnknownResourceExtensionError):
            # The renderer for '.unknown' is not yet defined.
>           Resource(foo, 'nothing.unknown')
E           Failed: DID NOT RAISE <class 'fanstatic.core.UnknownResourceExtensionError'>

```